### PR TITLE
initial commit of Asciidoctor backend

### DIFF
--- a/slim/packt/document.fodt.slim
+++ b/slim/packt/document.fodt.slim
@@ -1,0 +1,58 @@
+|<?xml version='1.0' encoding='#{attr :encoding}'?>
+office:document(
+  office:version='1.2'
+  office:mimetype='application/vnd.oasis.opendocument.text'
+  xmlns:office='urn:oasis:names:tc:opendocument:xmlns:office:1.0'
+  xmlns:style='urn:oasis:names:tc:opendocument:xmlns:style:1.0'
+  xmlns:text='urn:oasis:names:tc:opendocument:xmlns:text:1.0'
+  xmlns:table='urn:oasis:names:tc:opendocument:xmlns:table:1.0'
+  xmlns:draw='urn:oasis:names:tc:opendocument:xmlns:drawing:1.0'
+  xmlns:fo='urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0'
+  xmlns:xlink='http://www.w3.org/1999/xlink'
+  xmlns:dc='http://purl.org/dc/elements/1.1/'
+  xmlns:meta='urn:oasis:names:tc:opendocument:xmlns:meta:1.0'
+  xmlns:number='urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0'
+  xmlns:svg='urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0'
+  xmlns:chart='urn:oasis:names:tc:opendocument:xmlns:chart:1.0'
+  xmlns:dr3d='urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0'
+  xmlns:math='http://www.w3.org/1998/Math/MathML'
+  xmlns:form='urn:oasis:names:tc:opendocument:xmlns:form:1.0'
+  xmlns:script='urn:oasis:names:tc:opendocument:xmlns:script:1.0'
+  xmlns:config='urn:oasis:names:tc:opendocument:xmlns:config:1.0'
+  xmlns:ooo='http://openoffice.org/2004/office'
+  xmlns:ooow='http://openoffice.org/2004/writer'
+  xmlns:oooc='http://openoffice.org/2004/calc'
+  xmlns:dom='http://www.w3.org/2001/xml-events'
+  xmlns:xforms='http://www.w3.org/2002/xforms'
+  xmlns:xsd='http://www.w3.org/2001/XMLSchema'
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns:rpt='http://openoffice.org/2005/report'
+  xmlns:of='urn:oasis:names:tc:opendocument:xmlns:of:1.2'
+  xmlns:xhtml='http://www.w3.org/1999/xhtml'
+  xmlns:grddl='http://www.w3.org/2003/g/data-view#'
+  xmlns:tableooo='http://openoffice.org/2009/table'
+  xmlns:field='urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0'
+  xmlns:formx='urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0'
+  xmlns:css3t='http://www.w3.org/TR/css3-text/')
+  office:meta
+    dc:title=(doctitle sanitize: true)
+    - [[:subject, :keywords], [:description, :description], [:creator, :author], [:language, :lang]].each do |(tag,key)|
+      - if attr? key
+        *{tag: %(dc:#{tag})} =(attr key)
+    meta:creation-date=(dt = ::DateTime.parse((attr? :revdate) ? (attr :revdate) : (attr :docdate)).strftime '%Y-%m-%dT%H:%M:%S')
+    dc:date=dt
+    meta:initial-creator=(attr :author)
+    meta:generator=%(Asciidoctor #{attr 'asciidoctor-version'})
+    - [:author, :email, :version].each do |key|
+      - if attr? key
+        meta:user-defined meta:name=key =(attr key)
+  office:scripts
+    office:event-listeners
+      - if attr? :toc
+        script:event-listener script-language='ooo:script' script:event-name='dom:load' xlink:href='.uno:UpdateAllIndexes'
+  office:body
+    office:text text:use-soft-page-breaks='true'
+      text:p text:style-name='cover-text'
+        text:span text:style-name='author'
+          text:author-name text:fixed='true' =(attr :author)
+      /=content

--- a/slim/packt/helpers.rb
+++ b/slim/packt/helpers.rb
@@ -1,0 +1,2 @@
+require 'time'
+Asciidoctor::DEFAULT_EXTENSIONS['packt'] = '.fodt'


### PR DESCRIPTION
Here's the very start of a packt backend for use with Asciidoctor. I choose to use the slim template languages because it's the most concise language for creating XML output.

I've just done (most of) the document template so far. This covers the [header] and [footer] parts of the AsciiDoc Python backend. The next step is to do the paragraph block, then enable call to `=content` in the document template. Once you have these started, the rest should come quickly.
