### PR TITLE
Update keyword styling

### DIFF
--- a/slim/packt/inline_quoted.fodt.slim
+++ b/slim/packt/inline_quoted.fodt.slim
@@ -1,16 +1,13 @@
 - case @type
-- when :emphasis
-  text:span text:style="strong" data-style="emphasis"
-    =text
 - when :strong
   / the double underscore is escaped so it doesn't get interpretted as an unconstrained emphasis
-  text:span text:style-name="Key_20_Word_20\__5b_PACKT_5d_"
+  text:span text:style-name="Key_20_Word_20__5b_PACKT_5d_"
     =text
 - when :monospaced
   text:span text:style-name="Code_20_In_20_Text_20__5b_PACKT_5d_"
     =text
+- when :emphasis
+  =text
 - else
   text:span text:style="strong" data-style="else"
     =text
-    
-    


### PR DESCRIPTION
This contains the proper style. The problem is, when applied to:

```
If you'll notice, all lines of that bullet list are tagged **Bullet [PACKT]**, except the last. It's tagged
**Bullet End [PACKT]**.
```

...it renders:

``` xml
<text:p text:style-name="Normal_20__5b_PACKT_5d_">If you’ll notice, all lines of that bullet 
list are tagged <text:span text:style="Key_20_Word_205b_PACKT_5d_">Bullet [PACKT]</text:span>, 
except the last. It’s tagged <text:span text:style="Key_20_Word_205b_PACKT_5d_">Bullet 
End [PACKT]</text:span>.</text:p>
```

The double-underscore is trimmed out for some reason.

In another situation, it doesn't do that.

```
The output will be compacted XML (FODT), so it will be **hard** to read. That why running it through
`xmllint` is handy.
```

renders

``` xml
      <text:p text:style-name="Normal_20__5b_PACKT_5d_">The output will be compacted XML 
(FODT), so it will be <text:span text:style="Key_20_Word_20__5b_PACKT_5d_">hard</text:span> 
to read. That why running it through xmllint is handy.</text:p>
```
