### PR TITLE
Redo the section layout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,9 @@
-== 43
-=== Writing for Packt with Asciidoctor
+:author: Greg L. Turnquist
+:firstname: Greg
+:lastname: Turnquist
+:chapter_number: 43
+
+= Writing for Packt with Asciidoctor
 
 In this chapter, you'll learn:
 
@@ -11,7 +15,7 @@ In this chapter, you'll learn:
 If you'll notice, all lines of that bullet list are tagged **Bullet [PACKT]**, except the last. It's tagged
 **Bullet End [PACKT]**.
 
-==== Getting started
+== Getting started
 
 [verse, Greg L. Turnquist]
 "After writing gobs of documents over the past year with AsciiDoc, I was strongly motivated to make that work 
@@ -66,7 +70,7 @@ Cheers!
 WARNING: This is HIGHLY experimental. I haven't completed the entire book submission process. If you take this
 on you assume ALL risk.
 
-==== Quotes
+== Quotes
 
 I decided to add quotes. There seemed to a lot of proverbial good ones bubbling up regarding Spring Boot, the topic of this
 endeavor. So I needed a way to wrap them up properly. It turns out that I preferred the verse over quote, so that's the styling
@@ -84,7 +88,7 @@ as I embark on writing Learning Spring Boot."
 If you want to cite the source, add the third clause. It will be appended to the end after a ",". NOTE: There is no additional formatting applied, like URL types. Instead, the entire block is marked up with Packt's QUOTE style. Hence, you might want to
 debate if this is REALLY needed.
 
-==== Code
+== Code
 
 Nothing is complete without looking at code.
 
@@ -96,20 +100,37 @@ include::samples/app.groovy[]
 This chunk of code is Groovy (http://groovy.codehaus.org). It contains the `@RestController` to flag the entire class as being a controller that
 returns values directly back to the client, without invoking any views.
 
-===== Subsections
+== Subsections
 
-Yes, we handle subsections, but so far, only levels 2-5.
+Yes, we handle subsections.
 
-* Level 2 is for the chapter number
-* Level 3 is for the chapter title
-* Level 4 is for major sections
-* Level 5 is for sub-sections
+* Level 1 is the title of the chapter.
 
-It might be possible to go deeper, but I frankly haven't needed that yet.
+== Level 1 Section
+
+This is **Heading 1 [PACKT]**.
+
+=== Level 2 Section
+
+This is **Heading 2 [PACKT]**.
+
+==== Level 3 Section
+
+This is **Heading 3 [PACKT]**.
+
+===== Level 4 Section
+
+This is **Heading 4 [PACKT]**.
+
+====== Level 5 Section
+
+This is **Heading 5 [PACKT]**.
+
+As for **Heading 6 [PACKT]**, Asciidoctor doesn't go that deep. In my opinion, I have yet to read a book that needs this many levels.
 
 NOTE: This doesn't apply to Packt Cookbook formats.
 
-===== Tables
+=== Tables
 
 We sure do cover them. Tables are an integral part of writing any manuscript. Check out the
 following table.
@@ -124,11 +145,11 @@ following table.
 |====
 {empty}
 
-==== Images
+== Images
 
 image::samples/cat.jpg[width="65%" height="30%"]
 
-==== What are some of the things you don't cover?
+== What are some of the things you don't cover?
 
 Well, there are actually a lot of other styles provided by Packt not handled here. 
 
@@ -144,11 +165,11 @@ pulls me away from writing, so I don't support it.
 WARNING: All styles embedded in this backend are owned by Packt Publishing Ltd. (http://packtpub.com) and potentially subject to their
 copyright notices.
 
-==== Good to know stuff...
+== Good to know stuff...
 
 * Don't embed :author: or :title: attributes at the top. They end up getting printed which fouls up the product you must ship to Packt.
 
-==== In case you didn't notice
+== In case you didn't notice
 
 This README page is structured in the theme of Packt. It might not render perfectly on GitHub, but when viewed through a text editor, 
 and certainly when converted by this backend to LibreOffice, it should provide a nice example of writing a manuscript for Packt.

--- a/slim/packt/document.fodt.slim
+++ b/slim/packt/document.fodt.slim
@@ -1072,7 +1072,14 @@ office:document(
 
   office:body
     office:text text:use-soft-page-breaks='true'
-      text:p text:style-name='cover-text'
-        text:span text:style-name='author'
-          text:author-name text:fixed='true' =(attr :author)
+      - if (attr? :chapter_number)
+        text:h text:style-name="Chapter_20_Number_20__5b_PACKT_5d_" text:outline-level="1" 
+          text:bookmark-start text:name="_#{(attr :chapter_number)}"
+          =(attr :chapter_number)
+          text:bookmark-end text:name="_#{(attr :chapter_number)}"
+      - else
+        text:h text:style-name="Chapter_20_Number_20__5b_PACKT_5d_" text:outline-level="1" 
+          text:bookmark-start text:name="_1" 
+          |1
+          text:bookmark-end text:name="_1"
       =content

--- a/slim/packt/preamble.fodt.slim
+++ b/slim/packt/preamble.fodt.slim
@@ -1,0 +1,6 @@
+text:h text:style-name="Chapter_20_Title_20__5b_PACKT_5d_" text:outline-level="2" 
+  text:bookmark-start text:name="#{@id}" 
+  |#{title}
+  =title
+  text:bookmark-end text:name="#{@id}"
+=content

--- a/slim/packt/section.fodt.slim
+++ b/slim/packt/section.fodt.slim
@@ -1,24 +1,36 @@
 - slevel = @level == 0 && @special ? 1 : @level
-- if slevel == 1
-  text:h text:style-name="Chapter_20_Number_20__5b_PACKT_5d_" text:outline-level="1" 
-    text:bookmark-start text:name="#{@id}" 
-    |#{title}
-    text:bookmark-end text:name="#{@id}"
-  =content
-- if slevel == 2
+- if slevel == 0
   text:h text:style-name="Chapter_20_Title_20__5b_PACKT_5d_" text:outline-level="2" 
     text:bookmark-start text:name="#{@id}" 
     |#{title}
     text:bookmark-end text:name="#{@id}"
   =content
+- if slevel == 1
+  text:h text:style-name="Heading_20_1_2c_Heading_20_1_20__5b_PACKT_5d_" text:outline-level="3" 
+    text:bookmark-start text:name="#{@id}" 
+    |#{title}
+    text:bookmark-end text:name="#{@id}"
+  =content
+- if slevel == 2
+  text:h text:style-name="Heading_20_2_2c_Heading_20_2_20__5b_PACKT_5d_" text:outline-level="4" 
+    text:bookmark-start text:name="#{@id}" 
+    |#{title}
+    text:bookmark-end text:name="#{@id}"
+  =content
 - if slevel == 3
-  text:h text:style-name="Heading_20_1" text:outline-level="3" 
+  text:h text:style-name="Heading_20_3_2c_Heading_20_3_20__5b_PACKT_5d_" text:outline-level="3" 
     text:bookmark-start text:name="#{@id}" 
     |#{title}
     text:bookmark-end text:name="#{@id}"
   =content
 - if slevel == 4
-  text:h text:style-name="Heading_20_2" text:outline-level="4" 
+  text:h text:style-name="Heading_20_4_2c_Heading_20_4_20__5b_PACKT_5d_" text:outline-level="4" 
+    text:bookmark-start text:name="#{@id}" 
+    |#{title}
+    text:bookmark-end text:name="#{@id}"
+  =content
+- if slevel == 5
+  text:h text:style-name="Heading_20_5_2c_Heading_20_5_20__5b_PACKT_5d_" text:outline-level="3" 
     text:bookmark-start text:name="#{@id}" 
     |#{title}
     text:bookmark-end text:name="#{@id}"


### PR DESCRIPTION
- Fix the Packt style used
- Pull out chapter number as a section and instead rely on attribute :chapter_number, defaulting to **1** if not specified
- Move everything up, so that main sections are Level 1, i.e. `==`, etc.
- Add a preamble

Issues:
- Can't seem to grab the title inside the preamble. docbook's block_preamble.xml.slim seems to use it. Why can't I?
- If the Chapter Title styling works, do I need to then rip it's relic out of section.fodt.slim?
